### PR TITLE
Fixed page scrolling issue on touch devices

### DIFF
--- a/joy.js
+++ b/joy.js
@@ -96,14 +96,14 @@ var JoyStick = (function(container, parameters)
 	if("ontouchstart" in document.documentElement)
 	{
 		canvas.addEventListener("touchstart", onTouchStart, false);
-		document.addEventListener("touchmove", onTouchMove, false);
-		document.addEventListener("touchend", onTouchEnd, false);
+		canvas.addEventListener("touchmove", onTouchMove, false);
+		canvas.addEventListener("touchend", onTouchEnd, false);
 	}
 	else
 	{
 		canvas.addEventListener("mousedown", onMouseDown, false);
-		document.addEventListener("mousemove", onMouseMove, false);
-		document.addEventListener("mouseup", onMouseUp, false);
+		canvas.addEventListener("mousemove", onMouseMove, false);
+		canvas.addEventListener("mouseup", onMouseUp, false);
 	}
 	// Draw the object
 	drawExternal();


### PR DESCRIPTION
While using the joystick on smartphone, page scrolling was not disabled. It was working fine on the website "https://bobboteck.github.io/joy/joy.html " and I just copied the changes from there.