### PR TITLE
Support multiple joysticks

### DIFF
--- a/joy.js
+++ b/joy.js
@@ -175,9 +175,11 @@ var JoyStick = (function(container, parameters, callback)
     /**
      * @desc Events for manage touch
      */
-    function onTouchStart(event) 
+    let touchId = null;
+    function onTouchStart(event)
     {
         pressed = 1;
+        touchId = event.targetTouches[0].identifier;
     }
 
     function onTouchMove(event)
@@ -211,10 +213,12 @@ var JoyStick = (function(container, parameters, callback)
             StickStatus.cardinalDirection = getCardinalDirection();
             callback(StickStatus);
         }
-    } 
+    }
 
-    function onTouchEnd(event) 
+    function onTouchEnd(event)
     {
+        if (event.changedTouches[0].identifier !== touchId) return;
+
         pressed = 0;
         // If required reset position store variable
         if(autoReturnToCenter)


### PR DESCRIPTION
I saw the other pull request for fixing this same problem, but I think this solution may be cleaner.

Support multiple joysticks by saving the ID of the touch point when a canvas is touched. Then when a touch is ended anywhere in the document, each joystick compares the ended touch ID with the touch ID associated with its canvas to know whether to honor that touch end event.

By the way, didn't see a way to generate the minified JS. Would recommend including a command to do so somewhere, perhaps as a npm script.